### PR TITLE
Fix: Clear function caches for PHP 5.4+

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -6,6 +6,6 @@ PHP_ARG_ENABLE(rename, whether to enable function rename support,
 [  --enable-rename          Enable function rename support])
 
 if test "$PHP_RENAME" != "no"; then
-	rename_sources="php_rename.c "
+	rename_sources="php_rename.c php_rename_cache.c "
 	PHP_NEW_EXTENSION(rename, $rename_sources, $ext_shared)
 fi

--- a/php_rename.c
+++ b/php_rename.c
@@ -71,7 +71,7 @@ PHP_FUNCTION(rename_function)
 	}
 	lower_new[i] = 0;
 
-  if (zend_hash_find(EG(function_table), lower_orig, orig_fname_len + 1, (void **) &func) == FAILURE) {
+	if (zend_hash_find(EG(function_table), lower_orig, orig_fname_len + 1, (void **) &func) == FAILURE) {
 		php_error_docref(NULL TSRMLS_CC, E_WARNING, "%s(%s, %s) failed: %s does not exist!"			,
 						get_active_function_name(TSRMLS_C),
 						lower_orig,  lower_new, lower_orig);
@@ -111,6 +111,11 @@ PHP_FUNCTION(rename_function)
 		RETVAL_FALSE;
 		goto rename_end;
 	}
+
+#if (PHP_MAJOR_VERSION == 5 && PHP_MINOR_VERSION >= 4) || (PHP_MAJOR_VERSION > 5)
+	rename_cache_clear_all_functions(TSRMLS_C);
+#endif
+
 	RETVAL_TRUE;
 
 rename_end:

--- a/php_rename.h
+++ b/php_rename.h
@@ -28,6 +28,10 @@ extern zend_module_entry rename_module_entry;
 
 PHP_FUNCTION(rename_function);
 
+#if (PHP_MAJOR_VERSION == 5 && PHP_MINOR_VERSION >= 4) || (PHP_MAJOR_VERSION > 5)
+void rename_cache_clear_all_functions(TSRMLS_D);
+#endif
+
 #endif  /* PHP_RENAME_H */
 
 /*

--- a/php_rename_cache.c
+++ b/php_rename_cache.c
@@ -1,0 +1,95 @@
+/*
+  +----------------------------------------------------------------------+
+  | PHP Version 5                                                        |
+  +----------------------------------------------------------------------+
+  | Copyright (c) 1997-2006 The PHP Group, (c) 2008-2012 Dmitry Zenovich |
+  +----------------------------------------------------------------------+
+  | This source file is subject to the new BSD license,                  |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | http://www.opensource.org/licenses/BSD-3-Clause                      |
+  | If you did not receive a copy of the license and are unable to       |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Author: Sara Golemon <pollita@php.net>                               |
+  | Modified by Dmitry Zenovich <dzenovich@gmail.com>                    |
+  +----------------------------------------------------------------------+
+  | https://github.com/zenovich/runkit                                   |
+  +----------------------------------------------------------------------+
+*/
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include "php.h"
+#include "php_rename.h"
+#include "Zend/zend_closures.h"
+
+typedef struct _zend_closure {
+    zend_object    std;
+    zend_function  func;
+    HashTable     *debug_info;
+} zend_closure;
+
+#if (PHP_MAJOR_VERSION == 5 && PHP_MINOR_VERSION >= 4) || (PHP_MAJOR_VERSION > 5)
+/* {{{ rename_cache_clear_function */
+static int rename_cache_clear_function(void *pDest TSRMLS_DC)
+{
+	zend_function *f = (zend_function *) pDest;
+
+	if (pDest == NULL || f->type != ZEND_USER_FUNCTION ||
+		f->op_array.last_cache_slot == 0 || f->op_array.run_time_cache == NULL) {
+		return ZEND_HASH_APPLY_KEEP;
+	}
+
+	memset(f->op_array.run_time_cache, 0, (f->op_array.last_cache_slot) * sizeof(void*));
+
+	return ZEND_HASH_APPLY_KEEP;
+}
+/* }}} */
+
+/* {{{ rename_cache_clear_all_functions */
+void rename_cache_clear_all_functions(TSRMLS_D)
+{
+	int i, count;
+	zend_execute_data *ptr;
+	HashPosition pos;
+
+	zend_hash_apply(EG(function_table), rename_cache_clear_function TSRMLS_CC);
+
+	zend_hash_internal_pointer_reset_ex(EG(class_table), &pos);
+	count = zend_hash_num_elements(EG(class_table));
+	for (i = 0; i < count; ++i) {
+		zend_class_entry **curce;
+		zend_hash_get_current_data_ex(EG(class_table), (void*)&curce, &pos);
+		zend_hash_apply(&(*curce)->function_table, rename_cache_clear_function TSRMLS_CC);
+		zend_hash_move_forward_ex(EG(class_table), &pos);
+	}
+
+	for (ptr = EG(current_execute_data); ptr != NULL; ptr = ptr->prev_execute_data) {
+		if (ptr->op_array == NULL || ptr->op_array->last_cache_slot == 0 || ptr->op_array->run_time_cache == NULL) {
+			continue;
+		}
+		memset(ptr->op_array->run_time_cache, 0, (ptr->op_array->last_cache_slot) * sizeof(void*));
+	}
+
+	if (!EG(objects_store).object_buckets) {
+		return;
+	}
+
+	for (i = 1; i < EG(objects_store).top ; i++) {
+		if (EG(objects_store).object_buckets[i].valid && (!EG(objects_store).object_buckets[i].destructor_called) &&
+			EG(objects_store).object_buckets[i].bucket.obj.object) {
+			zend_object *object;
+			object = (zend_object *) EG(objects_store).object_buckets[i].bucket.obj.object;
+			if (object->ce == zend_ce_closure) {
+				zend_closure *cl = (zend_closure *) object;
+				rename_cache_clear_function((void*) &cl->func TSRMLS_CC);
+			}
+		}
+	}
+}
+/* }}} */
+#endif


### PR DESCRIPTION
We need to clear out the function caches on newer version of PHP
when renaming a function. Otherwise it'll explode when it hits
an out-of-sync cache.

This is taken from the Runkit PHP extension:

https://github.com/zenovich/runkit
https://github.com/zenovich/runkit/blob/master/runkit_functions.c
